### PR TITLE
Fix unrecognized setUserId objective-C method on iOS

### DIFF
--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -14,7 +14,7 @@ class ReactNativeMatomo: NSObject {
         resolve(nil)
     }
 
-    @objc(setUserId:withResolver:WithRejecter:)
+    @objc(setUserId:withResolver:withRejecter:)
     func setUserId(userID:String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         if (tracker != nil) {
             tracker.userId = userID


### PR DESCRIPTION
Small typo that causes unrecognized objective-c method issue on iOS when setting the userId. 