### PR TITLE
[Technical] Update Android SDK version; Add iOS SDK version to podspec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Matomo wrapper for React-Native. Supports Android and iOS. Fixed issues for nati
 ---
 ## Installation
 - Requires React Native version 0.60.0, or later.
-- Supports iOS 10.0, or later.
+- Supports iOS 11.0, or later.
+- Supports Matomo SDK:
+ - Android: 4.2
+ - iOS: 7.6.0
 
 After that you can install it as usual.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -144,7 +144,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-  implementation 'com.github.matomo-org:matomo-sdk-android:4.1.4'
+  implementation 'com.github.matomo-org:matomo-sdk-android:4.2'
 // From node_modules
 }
 

--- a/mccsoft-react-native-matomo.podspec
+++ b/mccsoft-react-native-matomo.podspec
@@ -12,14 +12,14 @@ Pod::Spec.new do |s|
   s.authors       = package["author"]
 
   s.swift_version = '5.0'
-  s.platforms     = { :ios => "10.0" }
+  s.platforms     = { :ios => "11.0" }
   s.source        = { :git => "https://github.com/mccsoft/react-native-matomo.git", :tag => "#{s.version}" }
 
 
   s.source_files  = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "MatomoTracker", "7.5.2"
+  s.dependency "MatomoTracker", "7.6.0"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/mccsoft-react-native-matomo.podspec
+++ b/mccsoft-react-native-matomo.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "MatomoTracker"
+  s.dependency "MatomoTracker", "7.5.2"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
As new version of Android SDK was introduced (https://github.com/matomo-org/matomo-sdk-android/releases/tag/4.2) we can update it. Also we should keep exact iOS SDK version in podspec. 

Changelog:
- Bump Matomo Android SDK to 4.2
- Bump Matomo iOS SDK to 7.6.0
- Matomo iOS SDK 7.6.0 added Privacy Manifest
- Increased deployment target to iOS 11 