### PR TITLE
Allow to use cached events queue on iOS; Allow to dispatch events manually; Allow to set and get dispach interval 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ You can easily find out is Matomo tracker initialized or not. Call this method a
 await Matomo.isInitialized();
 ```
 
+#### Dispatch events manually
+
+Sometimes there is a need to dispach events manully:
+
+```javascript
+Matomo.dispatch();
+```
+
 ### Mocking
 
 Add this to mock specific function as you wish

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Before using any function below, the tracker must be initialized.
 Matomo.initialize('https://your-matomo-domain.tld/piwik.php', 1);
 ```
 
+On Android events queue is by default cached on disk, so events are not lost when user close the app. On iOS by default evetns queue is saved in memory, howeve you con opt in to use cached queue on iOS as well by initilaizing tracker with third option:
+
+```javascript
+Matomo.initialize('https://your-matomo-domain.tld/piwik.php', 1, true);
+```
+
 #### Set User ID
 
 Providing the tracker with a user ID lets you connect data collected from multiple devices and multiple browsers for the same user. A user ID is typically a non empty string such as username, email address or UUID that uniquely identifies the user. The User ID must be the same for a given user across all her devices and browsers. .

--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ Sometimes there is a need to dispach events manully:
 Matomo.dispatch();
 ```
 
+#### Set dispatch interval in seconds
+
+There is an option to change dispatch interval using seconds:
+
+```javascript
+Matomo.setDispatchInterval(30)
+```
+
+#### Get dispatch internatl
+You can easily find out current dispatch interanl in seconds. Call this method and get `number` value, use:
+
+```javascript
+await Matomo.getDispatchInterval();
+```
+
 ### Mocking
 
 Add this to mock specific function as you wish

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Before using any function below, the tracker must be initialized.
 Matomo.initialize('https://your-matomo-domain.tld/piwik.php', 1);
 ```
 
-On Android events queue is by default cached on disk, so events are not lost when user close the app. On iOS by default evetns queue is saved in memory, howeve you con opt in to use cached queue on iOS as well by initilaizing tracker with third option:
+On Android events queue is by default cached on disk, so events are not lost when user close the app. On iOS by default evetns queue is saved in memory, however you con opt in to use cached queue on iOS as well by initilaizing tracker with third option:
 
 ```javascript
 Matomo.initialize('https://your-matomo-domain.tld/piwik.php', 1, true);

--- a/android/src/main/java/com/mccsoft/reactnativematomo/ReactNativeMatomoModule.java
+++ b/android/src/main/java/com/mccsoft/reactnativematomo/ReactNativeMatomoModule.java
@@ -152,6 +152,17 @@ public class ReactNativeMatomoModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void dispatch(Promise promise) {
+    try {
+      tracker.dispatch();
+
+      promise.resolve(null);
+    } catch (Exception e) {
+      promise.reject(e);
+    }
+  }
+
   private TrackHelper getTrackHelper() {
     if (tracker == null) {
       throw new RuntimeException("Tracker must be initialized before usage");

--- a/android/src/main/java/com/mccsoft/reactnativematomo/ReactNativeMatomoModule.java
+++ b/android/src/main/java/com/mccsoft/reactnativematomo/ReactNativeMatomoModule.java
@@ -19,6 +19,7 @@ import org.matomo.sdk.extra.TrackHelper;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @ReactModule(name = ReactNativeMatomoModule.NAME)
 public class ReactNativeMatomoModule extends ReactContextBaseJavaModule {
@@ -158,6 +159,35 @@ public class ReactNativeMatomoModule extends ReactContextBaseJavaModule {
       tracker.dispatch();
 
       promise.resolve(null);
+    } catch (Exception e) {
+      promise.reject(e);
+    }
+  }
+
+  @ReactMethod
+  public void setDispatchInterval(int seconds, Promise promise) {
+    try {
+      if (tracker != null) {
+        tracker.setDispatchInterval(TimeUnit.SECONDS.toMillis(seconds));
+        promise.resolve(null);
+      } else {
+        promise.reject("not_initialized", "Matomo not initialized");
+      }
+    } catch (Exception e) {
+      promise.reject(e);
+    }
+  }
+
+  @ReactMethod
+  public void getDispatchInterval(Promise promise) {
+    try {
+      if (tracker != null) {
+        long intervalMillis = tracker.getDispatchInterval();
+        int intervalSeconds = (int) TimeUnit.MILLISECONDS.toSeconds(intervalMillis);
+        promise.resolve(intervalSeconds);
+      } else {
+        promise.reject("not_initialized", "Matomo not initialized");
+      }
     } catch (Exception e) {
       promise.reject(e);
     }

--- a/ios/ReactNativeMatomo.m
+++ b/ios/ReactNativeMatomo.m
@@ -10,26 +10,35 @@ RCT_EXTERN_METHOD(initialize:(NSString*)url withId:(NSNumber* _Nonnull)id
                   withCachedQueue:(BOOL _Nonnull)cachedQueue
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(setUserId:(NSString* _Nonnull)userID
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(setCustomDimension: (NSNumber* _Nonnull)index withValue:(NSString* _Nullable)value
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(trackView: (NSString* _Nonnull)path withTitle:(NSString* _Nullable)title
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(trackGoal: (NSNumber* _Nonnull)goal withValues:(NSDictionary* _Nonnull)values
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(trackEvent:(NSString* _Nonnull)category withAction:(NSString* _Nonnull)action withValues:(NSDictionary* _Nonnull)values
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(setAppOptOut:(BOOL _Nonnull) optOut
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(trackAppDownload:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject);
+
+RCT_EXTERN_METHOD(dispatch:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject);
 
 @end

--- a/ios/ReactNativeMatomo.m
+++ b/ios/ReactNativeMatomo.m
@@ -7,6 +7,7 @@
 }
 
 RCT_EXTERN_METHOD(initialize:(NSString*)url withId:(NSNumber* _Nonnull)id
+                  withCachedQueue:(BOOL _Nonnull)cachedQueue
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(setUserId:(NSString* _Nonnull)userID

--- a/ios/ReactNativeMatomo.m
+++ b/ios/ReactNativeMatomo.m
@@ -41,4 +41,10 @@ RCT_EXTERN_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve withRejecter:(RC
 
 RCT_EXTERN_METHOD(dispatch:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(setDispatchInterval: (NSNumber* _Nonnull)seconds
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject);
+
+RCT_EXTERN_METHOD(getDispatchInterval:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject);
+
 @end

--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -98,7 +98,7 @@ class ReactNativeMatomo: NSObject {
     func isInitialized(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         resolve(tracker != nil)
     }
-
+
     @objc(setAppOptOut:withResolver:withRejecter:)
     func setAppOptOut(optOut:Bool, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         tracker.isOptedOut = optOut;
@@ -110,6 +110,25 @@ class ReactNativeMatomo: NSObject {
         if (tracker != nil) {
             tracker.dispatch()
             resolve(nil)
+        } else {
+            reject("not_initialized", "Matomo not initialized", nil)
+        }
+    }
+
+    @objc(setDispatchInterval:withResolver:withRejecter:)
+    func setDispatchInterval(seconds: NSNumber, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        if (tracker != nil) {
+            tracker.dispatchInterval = seconds.doubleValue
+            resolve(nil)
+        } else {
+            reject("not_initialized", "Matomo not initialized", nil)
+        }
+    }
+
+    @objc(getDispatchInterval:withRejecter:)
+    func getDispatchInterval(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        if (tracker != nil) {
+            resolve(tracker.dispatchInterval)
         } else {
             reject("not_initialized", "Matomo not initialized", nil)
         }

--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -18,7 +18,7 @@ class ReactNativeMatomo: NSObject {
         let siteId = id.stringValue
         
         if (cachedQueue) {
-            let queue = UserDefaultsCachedQueue(UserDefaults.standard, autoSave: true)
+            let queue = UserDefaultsCachedQueue(UserDefaults.standard, siteId: siteId, autoSave: true)
             let dispatcher = URLSessionDispatcher(baseURL: baseUrl!)
             tracker = MatomoTracker(siteId: siteId, queue: queue, dispatcher: dispatcher)
         } else {

--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -105,4 +105,13 @@ class ReactNativeMatomo: NSObject {
         resolve(nil)
     }
 
+    @objc(dispatch:withRejecter:)
+    func dispatch(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        if (tracker != nil) {
+            tracker.dispatch()
+            resolve(nil)
+        } else {
+            reject("not_initialized", "Matomo not initialized", nil)
+        }
+    }
 }

--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -6,11 +6,25 @@ class ReactNativeMatomo: NSObject {
 
     var tracker: MatomoTracker!
 
-    @objc(initialize:withId:withResolver:withRejecter:)
-    func initialize(url:String, id:NSNumber, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
+    @objc(initialize:withId:witchCachedQueue:withResolver:withRejecter:)
+    func initialize(
+        url:String,
+        id:NSNumber,
+        cachedQueue: Bool,
+        resolve:RCTPromiseResolveBlock,
+        reject:RCTPromiseRejectBlock) -> Void
+    {
         let baseUrl = URL(string:url)
         let siteId = id.stringValue
-        tracker = MatomoTracker(siteId: siteId, baseURL: baseUrl!)
+        
+        if (cachedQueue) {
+            let queue = UserDefaultsCachedQueue(UserDefaults.standard, autoSave: true)
+            let dispatcher = URLSessionDispatcher(baseURL: baseUrl!)
+            tracker = MatomoTracker(siteId: siteId, queue: queue, dispatcher: dispatcher)
+        } else {
+            tracker = MatomoTracker(siteId: siteId, baseURL: baseUrl!)
+        }
+        
         resolve(nil)
     }
 

--- a/ios/ReactNativeMatomo.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeMatomo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E7158C9E2C23022200D09368 /* UserDefaultsCachedQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7158C9D2C23020D00D09368 /* UserDefaultsCachedQueue.swift */; };
 		F4FF95D7245B92E800C19C63 /* ReactNativeMatomo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* ReactNativeMatomo.swift */; };
 /* End PBXBuildFile section */
 
@@ -25,6 +26,7 @@
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libReactNativeMatomo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactNativeMatomo.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5891CC2AC0600A0062D /* ReactNativeMatomo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReactNativeMatomo.m; sourceTree = "<group>"; };
+		E7158C9D2C23020D00D09368 /* UserDefaultsCachedQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsCachedQueue.swift; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* ReactNativeMatomo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReactNativeMatomo-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* ReactNativeMatomo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactNativeMatomo.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -54,6 +56,7 @@
 				F4FF95D6245B92E800C19C63 /* ReactNativeMatomo.swift */,
 				B3E7B5891CC2AC0600A0062D /* ReactNativeMatomo.m */,
 				F4FF95D5245B92E700C19C63 /* ReactNativeMatomo-Bridging-Header.h */,
+				E7158C9D2C23020D00D09368 /* UserDefaultsCachedQueue.swift */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -115,6 +118,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7158C9E2C23022200D09368 /* UserDefaultsCachedQueue.swift in Sources */,
 				F4FF95D7245B92E800C19C63 /* ReactNativeMatomo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/UserDefaultsCachedQueue.swift
+++ b/ios/UserDefaultsCachedQueue.swift
@@ -1,0 +1,66 @@
+import Foundation
+import MatomoTracker
+
+public final class UserDefaultsCachedQueue: NSObject, Queue {
+    private var items: [Event] {
+        didSet {
+            if autoSave {
+                try? UserDefaultsCachedQueue.write(items, to: userDefaults)
+            }
+        }
+    }
+    private let userDefaults: UserDefaults
+    private let autoSave: Bool
+    
+    init(_ userDefaults: UserDefaults, autoSave: Bool = false) {
+        self.userDefaults = userDefaults
+        self.autoSave = autoSave
+        self.items = (try? UserDefaultsCachedQueue.readEvents(from: userDefaults)) ?? []
+        super.init()
+    }
+    
+    public var eventCount: Int {
+        return items.count
+    }
+    
+    public func enqueue(events: [Event], completion: (()->())?) {
+        items.append(contentsOf: events)
+        completion?()
+    }
+    
+    public func first(limit: Int, completion: (_ items: [Event])->()) {
+        let amount = [limit,eventCount].min()!
+        let dequeuedItems = Array(items[0..<amount])
+        completion(dequeuedItems)
+    }
+    
+    public func remove(events: [Event], completion: ()->()) {
+        items = items.filter({ event in !events.contains(where: { eventToRemove in eventToRemove.uuid == event.uuid })})
+        completion()
+    }
+    
+    public func save() throws {
+        try UserDefaultsCachedQueue.write(items, to: userDefaults)
+    }
+}
+
+extension UserDefaultsCachedQueue {
+    
+    private static let userDefaultsKey: String = {
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "default"
+        return "\(bundleIdentifier).UserDefaultsQueue.items"
+    }()
+    
+    private static func readEvents(from userDefaults: UserDefaults) throws -> [Event] {
+        guard let data = userDefaults.data(forKey: userDefaultsKey) else { return [] }
+        let decoder = JSONDecoder()
+        return try decoder.decode([Event].self, from: data)
+    }
+    
+    private static func write(_ events: [Event], to userDefaults: UserDefaults) throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(events)
+        userDefaults.set(data, forKey: userDefaultsKey)
+    }
+    
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -78,6 +78,22 @@ export function dispatch(): Promise<void> {
   return ReactNativeMatomo.dispatch();
 }
 
+export function setDispatchInterval(seconds: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (typeof seconds !== 'number' || seconds <= 0) {
+      reject(new Error('Invalid interval. The value must be a positive number.'));
+    } else {
+      ReactNativeMatomo.setDispatchInterval(seconds)
+        .then(resolve)
+        .catch(reject);
+    }
+  });
+}
+
+export function getDispatchInterval(): Promise<number> {
+  return ReactNativeMatomo.getDispatchInterval();
+}
+
 export default {
   initialize: initialize,
   isInitialized: isInitialized,
@@ -89,4 +105,6 @@ export default {
   setUserId: setUserId,
   setAppOptOut: setAppOptOut,
   dispatch: dispatch,
+  setDispatchInterval: setDispatchInterval,
+  getDispatchInterval: getDispatchInterval,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,6 +74,10 @@ export function setAppOptOut(isOptedOut: boolean): Promise<void> {
   return ReactNativeMatomo.setAppOptOut(isOptedOut);
 }
 
+export function dispatch(): Promise<void> {
+  return ReactNativeMatomo.dispatch();
+}
+
 export default {
   initialize: initialize,
   isInitialized: isInitialized,
@@ -84,4 +88,5 @@ export default {
   setCustomDimension: setCustomDimension,
   setUserId: setUserId,
   setAppOptOut: setAppOptOut,
+  dispatch: dispatch,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,12 +17,17 @@ const ReactNativeMatomo = NativeModules.ReactNativeMatomo
       }
     );
 
-export function initialize(apiUrl: string, siteId: number): Promise<void> {
+export function initialize(apiUrl: string, siteId: number, cachedQueue?: boolean): Promise<void> {
   const normalizedUrlBase =
     apiUrl[apiUrl.length - 1] === '/'
       ? apiUrl.substring(0, apiUrl.length - 1)
       : apiUrl;
 
+  if (Platform.OS === 'ios') {
+    return ReactNativeMatomo.initialize(normalizedUrlBase, siteId, !!cachedQueue);
+  }
+
+  // On Android cached queue is enabled by default
   return ReactNativeMatomo.initialize(normalizedUrlBase, siteId);
 }
 


### PR DESCRIPTION
#### Description:

- On Android event queue is cached and saved on disk. On iOS queue is cached in memory, so events can be lost. To avoid that user should be able to opt in into cached queue on iOS as well. 

- Sometimes it's necessary to dispatch events manually without waiting for dispatcher to do it automatically. For that we need to expose `dispatch` method for iOS and Android. 

- Allow to set and get dispatch interval for iOS and Android. 