### PR TITLE
Add tvOS support; Add `trackSiteSearch` support; Make iOS/tvOS trackView implementation in sync with Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ You can easily find out current dispatch interanl in seconds. Call this method a
 await Matomo.getDispatchInterval();
 ```
 
+#### Track site search
+
+Track internal 'site' searches. (Requires Site Search to be active in Matomo website settings) Parameters are `query`, `category` and `resultCount`.
+
+```javascript
+Matomo.trackSiteSearch('Query', 'Category', 10);
+```
+
 ### Mocking
 
 Add this to mock specific function as you wish

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ Matomo wrapper for React-Native. Supports Android and iOS. Fixed issues for nati
 ---
 ## Installation
 - Requires React Native version 0.60.0, or later.
-- Supports iOS 11.0, or later.
+- Supports: 
+  - iOS: 11.0 and later
+  - tvOS: 13.0 and later
+  - Android SDK: 21 and later
 - Supports Matomo SDK:
- - Android: 4.2
- - iOS: 7.6.0
+  - Android: 4.2
+  - iOS/tvOS: 7.6.0
 
 After that you can install it as usual.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Matomo wrapper for React-Native. Supports Android and iOS. Fixed issues for nati
 - Requires React Native version 0.60.0, or later.
 - Supports: 
   - iOS: 11.0 and later
-  - tvOS: 13.0 and later
+  - tvOS: 13.0 and later (using `react-native-tvos`)
   - Android SDK: 21 and later
 - Supports Matomo SDK:
   - Android: 4.2

--- a/android/src/main/java/com/mccsoft/reactnativematomo/ReactNativeMatomoModule.java
+++ b/android/src/main/java/com/mccsoft/reactnativematomo/ReactNativeMatomoModule.java
@@ -193,6 +193,16 @@ public class ReactNativeMatomoModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void trackSiteSearch(String query, @Nullable String category, @Nullable Number resultCount, Promise promise) {
+    try {
+      getTrackHelper().search(query).category(category).resultCount(resultCount).with(tracker);
+      promise.resolve(null);
+    } catch (Exception e) {
+      promise.reject(e);
+    }
+  }
+
   private TrackHelper getTrackHelper() {
     if (tracker == null) {
       throw new RuntimeException("Tracker must be initialized before usage");

--- a/ios/ReactNativeMatomo.m
+++ b/ios/ReactNativeMatomo.m
@@ -47,4 +47,8 @@ RCT_EXTERN_METHOD(setDispatchInterval: (NSNumber* _Nonnull)seconds
 
 RCT_EXTERN_METHOD(getDispatchInterval:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(trackSiteSearch:(NSString* _Nonnull)query withCategory:(NSString* _Nullable)category withResultCount:(NSNumber* _Nonnull)resultCount
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject);
+
 @end

--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -53,14 +53,23 @@ class ReactNativeMatomo: NSObject {
     }
 
     @objc(trackView:withTitle:withResolver:withRejecter:)
-    func trackView(path:String, title:String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        if (tracker != nil) {
-            let views = path.components(separatedBy: "/")
-            tracker.track(view: views)
-            resolve(nil)
-        } else {
+    func trackView(path: String, title: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        guard let tracker = tracker else {
             reject("not_initialized", "Matomo not initialized. TrackView failed", nil)
-        }
+            return
+        }
+
+        let actionName = (title ?? path).components(separatedBy: "/")
+        let bundleIdentifier = Application.makeCurrentApplication().bundleIdentifier ?? "unknown"
+        let urlString = "http://\(bundleIdentifier)\(path)"
+        
+        guard let url = URL(string: urlString) else {
+            reject("invalid_url", "The generated URL is invalid.", nil)
+            return
+        }
+        
+        tracker.track(view: actionName, url: url)
+        resolve(nil)
     }
 
     @objc(trackGoal:withValues:withResolver:withRejecter:)

--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -133,4 +133,14 @@ class ReactNativeMatomo: NSObject {
             reject("not_initialized", "Matomo not initialized", nil)
         }
     }
+    
+    @objc(trackSiteSearch:withCategory:withResultCount:withResolver:withRejecter:)
+    func trackSiteSearch(query: String, category: String?, resultCount: NSNumber, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        if (tracker != nil) {
+            tracker.trackSearch(query: query, category: category, resultCount: resultCount.intValue)
+            resolve(nil)
+        } else {
+            reject("not_initialized", "Matomo not initialized", nil)
+        }
+    }
 }

--- a/mccsoft-react-native-matomo.podspec
+++ b/mccsoft-react-native-matomo.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.authors       = package["author"]
 
   s.swift_version = '5.0'
-  s.platforms     = { :ios => "11.0" }
+  s.platforms     = { :ios => "11.0", :tvos => "13.0" }
   s.source        = { :git => "https://github.com/mccsoft/react-native-matomo.git", :tag => "#{s.version}" }
 
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,6 +104,14 @@ export function getDispatchInterval(): Promise<number> {
   return ReactNativeMatomo.getDispatchInterval();
 }
 
+export function trackSiteSearch(
+  query: string,
+  category?: string,
+  resultCount?: number
+): Promise<void> {
+  return ReactNativeMatomo.trackSiteSearch(query, category, resultCount);
+}
+
 export default {
   initialize: initialize,
   isInitialized: isInitialized,
@@ -117,4 +125,5 @@ export default {
   dispatch: dispatch,
   setDispatchInterval: setDispatchInterval,
   getDispatchInterval: getDispatchInterval,
+  trackSiteSearch: trackSiteSearch,
 };


### PR DESCRIPTION
Changelog:

- Allow to build the project on tvOS (using `react-native-tvos`).
- Add `trackSiteSearch` method 
- Fix the `trackView` method on iOS / tvOS to behave like on the Android. Make `title` parameter optional

On Android `trackView` looks like this:

```java
  @ReactMethod
  public void trackView(String route, @Nullable String title, Promise promise) {
    try {
      String actualTitle = title == null ? route : title;
      getTrackHelper().screen(route).title(actualTitle).with(tracker);

      promise.resolve(null);
    } catch (Exception e) {
      promise.reject(e);
    }
  }
  ```
As you can see, it takes title if available or route. When we do deeper into SDK it looks like this:

```java
        public TrackMe build() {
            if (this.mPath == null) {
                throw new IllegalArgumentException("Screen tracking requires a non-empty path");
            } else {
                TrackMe trackMe = (new TrackMe(this.getBaseTrackMe())).set(QueryParams.URL_PATH, this.mPath).set(QueryParams.ACTION_NAME, this.mTitle).set(QueryParams.CAMPAIGN_NAME, this.mCampaignName).set(QueryParams.CAMPAIGN_KEYWORD, this.mCampaignKeyword);
                if (this.mCustomVariables.size() > 0) {
                    trackMe.set(QueryParams.SCREEN_SCOPE_CUSTOM_VARIABLES, this.mCustomVariables.toString());
                }

                Iterator var2 = this.mCustomDimensions.entrySet().iterator();

                while(var2.hasNext()) {
                    Map.Entry<Integer, String> entry = (Map.Entry)var2.next();
                    CustomDimension.setDimension(trackMe, (Integer)entry.getKey(), (String)entry.getValue());
                }

                return trackMe;
            }
        }
```

It sets `route` as `path` parameter:

```java
.set(QueryParams.URL_PATH, this.mPath)
```

and it sets `title` as a`action name` parameter:

```java
set(QueryParams.ACTION_NAME, this.mTitle).
```

