### PR TITLE
[iOS] Fix `witchCachedQueue` typo inside `ReactNativeMatomo.swift` file

### DIFF
--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -6,7 +6,7 @@ class ReactNativeMatomo: NSObject {
 
     var tracker: MatomoTracker!
 
-    @objc(initialize:withId:witchCachedQueue:withResolver:withRejecter:)
+    @objc(initialize:withId:withCachedQueue:withResolver:withRejecter:)
     func initialize(
         url:String,
         id:NSNumber,


### PR DESCRIPTION
This PR addresses typo inside the `ReactNativeMatomo,swift` and resolves issue https://github.com/mccsoft/react-native-matomo/issues/8

