### PR TITLE
Preserve nil values during RN <-> Obj-C <-> Swift bridge to avoid conversion to empty string

### DIFF
--- a/ios/ReactNativeMatomo.swift
+++ b/ios/ReactNativeMatomo.swift
@@ -39,7 +39,7 @@ class ReactNativeMatomo: NSObject {
     }
 
     @objc(setCustomDimension:withValue:withResolver:withRejecter:)
-    func setCustomDimension(index:NSNumber, value:String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+    func setCustomDimension(index:NSNumber, value:String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         if (tracker != nil) {
             if(value == nil){
                 tracker.remove(dimensionAtIndex: index.intValue)


### PR DESCRIPTION
Fix issue where nil optional values were incorrectly converted to empty strings ("") when passed through the React Native → Objective-C → Swift bridge. Now properly preserves nullability.