### PR TITLE
fix(ios): drop legacy new-arch podspec block that breaks RN 0.84+

### DIFF
--- a/mccsoft-react-native-matomo.podspec
+++ b/mccsoft-react-native-matomo.podspec
@@ -1,7 +1,6 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
   s.name          = "mccsoft-react-native-matomo"
@@ -20,19 +19,4 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   s.dependency "MatomoTracker", "7.8.0"
-
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  end
 end


### PR DESCRIPTION
#### Fixes: https://github.com/mccsoft/react-native-matomo/issues/13

#### Summary
Removes the conditional New Architecture (Fabric/TurboModules) pod dependencies and compiler flags from the podspec to fix compatibility with React Native 0.84+.

The library continues to work on New Architecture via RN's built-in interop layer, which wraps legacy RCTBridgeModule implementations automatically - no TurboModule/Codegen implementation is required on the library side.

#### Patch-Package workaround
Until this fix is published as a new release, users on RN 0.84+ can apply a patch-package patch as an immediate workaround.

[@mccsoft+react-native-matomo+1.0.8.patch](https://github.com/user-attachments/files/25462033/%40mccsoft%2Breact-native-matomo%2B1.0.8.patch)

